### PR TITLE
fix: [sc-14212] fix codegen for `additional_constraints` JSON schema support

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,6 +364,29 @@ params.gain.joints_map.at("joint1").interfaces_map.at("position").value
 params.gain.get_entry("joint1").get_entry("position").value
 ```
 
+### Additional Constraints
+The `additional_constraints` field is not mandatory but allows for user defined data to be packaged into the ParameterDescriptor.
+This is useful when you need to convey additional data, constraints, or instructions along with the parameter for your specific application,
+where it may not have access to the validators included in your `parameter.yaml`.
+For example, this could include a JSON schema which your UI uses to generate a form to update the parameter, or valid bounds for a value.
+
+```yaml
+cpp_namespace:
+  operating_mode:
+    type: string
+    default_value: "standby"
+    description: "Operating mode of the robot."
+    additional_constraints: "{\"$schema\":\"http://json-schema.org/draft-07/schema#\",\"enum\":[\"standby\",\"navigation\",\"take_over_the_world\"]}"
+  speed:
+    type: double
+    default_value: 5.0
+    description: "Speed of the robot in m/s."
+    additional_constraints: "{\"type\":\"number\",\"minimum\":0,\"maximum\":10}"
+    validation:
+        gt_eq<>: [0.0]
+        lt_eq<>: [10.0]
+```
+
 ### Use generated struct in Cpp
 The generated header file is named based on the target library name you passed as the first argument to the cmake function.
 If you specified it to be `turtlesim_parameters` you can then include the generated code with `#include <turtlesim/turtlesim_parameters.hpp>`.

--- a/generate_parameter_library_py/generate_parameter_library_py/string_filters_cpp.py
+++ b/generate_parameter_library_py/generate_parameter_library_py/string_filters_cpp.py
@@ -12,8 +12,7 @@ def valid_string_cpp(description):
     if description:
         # remove possible markdown/rst syntax, but add proper indent for cpp-header files.
         filtered_description = (
-            description
-            .replace('\\', '\\\\')
+            description.replace('\\', '\\\\')
             .replace('`', '')
             .replace('\n', '\\n    ')
             .replace('"', '\\"')
@@ -34,6 +33,6 @@ def valid_string_python(description):
       str: The filtered string that is a valid Python string.
     """
     if description:
-        return description.replace('\n', '\\n    ').replace('"','\\"')
+        return description.replace('\n', '\\n    ').replace('"', '\\"')
     else:
         return ''

--- a/generate_parameter_library_py/generate_parameter_library_py/string_filters_cpp.py
+++ b/generate_parameter_library_py/generate_parameter_library_py/string_filters_cpp.py
@@ -34,6 +34,6 @@ def valid_string_python(description):
       str: The filtered string that is a valid Python string.
     """
     if description:
-        return description.replace('\n', '\\n    ')
+        return description.replace('\n', '\\n    ').replace('"','\\"')
     else:
         return ''

--- a/generate_parameter_library_py/generate_parameter_library_py/string_filters_cpp.py
+++ b/generate_parameter_library_py/generate_parameter_library_py/string_filters_cpp.py
@@ -12,7 +12,11 @@ def valid_string_cpp(description):
     if description:
         # remove possible markdown/rst syntax, but add proper indent for cpp-header files.
         filtered_description = (
-            description.replace('\\', '\\\\').replace('`', '').replace('\n', '\\n    ')
+            description
+            .replace('\\', '\\\\')
+            .replace('`', '')
+            .replace('\n', '\\n    ')
+            .replace('"', '\\"')
         )
         return f'"{filtered_description}"'
     else:

--- a/generate_parameter_library_py/generate_parameter_library_py/test/valid_parameters.yaml
+++ b/generate_parameter_library_py/generate_parameter_library_py/test/valid_parameters.yaml
@@ -7,7 +7,7 @@ admittance_controller:
     type: string
     default_value: "spline"
     description: "specifies which algorithm to use for interpolation."
-    additional_constraints: '{\"$schema\":\"http://json-schema.org/draft-07/schema#\",\"enum\": [\"spline\", \"linear\"]}'
+    additional_constraints: "{\"$schema\":\"http://json-schema.org/draft-07/schema#\",\"enum\": [\"spline\", \"linear\"]}"
     validation:
       one_of<>: [ [ "spline", "linear" ] ]
       no_args_validator: null

--- a/generate_parameter_library_py/generate_parameter_library_py/test/valid_parameters.yaml
+++ b/generate_parameter_library_py/generate_parameter_library_py/test/valid_parameters.yaml
@@ -7,6 +7,7 @@ admittance_controller:
     type: string
     default_value: "spline"
     description: "specifies which algorithm to use for interpolation."
+    additional_constraints: '{\"$schema\":\"http://json-schema.org/draft-07/schema#\",\"enum\": [\"spline\", \"linear\"]}'
     validation:
       one_of<>: [ [ "spline", "linear" ] ]
       no_args_validator: null


### PR DESCRIPTION
# The bug:
Including a  JSON schema in the additional_constraints field of a parameter works in python (with a specific format but fails to generate for cpp. This is due to `YAML->Python->JINJA->GenFile` pipeline automatically escapes backslashes in strings to ensure generated files are valid. Unfortunately this turns `\"` into `\\"` which when written to C++ does not compile. 

So something like this in the `parameters.yaml`:
```YAML
additional_constraints: '{\"$schema\":\"http://json-schema.org/draft-07/schema#\",\"enum\":[\"none\",\"fastwrite\",\"zstd_fast\",\"zstd_small\"]}'
```
Is written to C++ as the below, which does not compile:
```C++
"{\\"$schema\\":\\"http://json-schema.org/draft-07/schema#\\",\\"enum\\":[\\"none\\",\\"fastwrite\\",\\"zstd_fast\\",\\"zstd_small\\"]}";
```

# Desired behavior:
Both C++ and Python generated parameters can have JSON schemas in their `additional_constraints` fields E.g.
```YAML
additional_constraints: "{\"$schema\":\"http://json-schema.org/draft-07/schema#\",\"enum\":[\"none\",\"fastwrite\",\"zstd_fast\",\"zstd_small\"]}"
```

# The solution:
Double escape quotes within the Python->Jinja conversion functions.
This allows for the YAML to be written in either of the below styles and still be generated correctly:
```YAML
additional_constraints: "{\"$schema\":\"http://json-schema.org/draft-07/schema#\",\"enum\":[\"none\",\"fastwrite\",\"zstd_fast\",\"zstd_small\"]}"
# OR
additional_constraints: '{"$schema":"http://json-schema.org/draft-07/schema#","enum":["none","fastwrite","zstd_fast","zstd_small"]}"'
```